### PR TITLE
Fix ChangeDirectory validation logic and add tests

### DIFF
--- a/src/ChangeDirectory.cpp
+++ b/src/ChangeDirectory.cpp
@@ -12,38 +12,37 @@ string ChangeDirectory::GetHelpContent()
 
 bool ChangeDirectory::HasValidParameters()
 {
-	bool valid = false;
-	int i = 0;
+	showHelp = false;
+	changeDrive = false;
+	pathIndex = 0;
 
-	if (parameters.size() == 0) {
-		valid = true;
-		showHelp = true;	
-	}else{
-		for (vector<string>::iterator it = parameters.begin(); it != parameters.end(); ++it) {
-			if (i == 0 && *it == "--help" && parameters.size() == 1) {
-				showHelp = true;
-				valid = true;
-			}
-			else if (i == 0 && *it == "/D" && parameters.size() < 3) {
-				changeDrive = true;
-				valid = true;
-			}
-			else if (i == 0 && parameters.size() == 1) {
-				pathIndex = i;
-				changeDrive = false;
-				showHelp = false;
-				valid = true;
-			}
-			else if (i == 1 && parameters.size() == 2){
-				pathIndex = i;
-				showHelp = false;
-				valid = true;
-			}
-			i++;
-		}
+	if (parameters.empty()) {
+		showHelp = true;
+		return true;
 	}
 
-	return valid;
+	if (parameters.size() == 1) {
+		if (parameters[0] == "--help") {
+			showHelp = true;
+			return true;
+		}
+		if (parameters[0] == "/D") {
+			return false;
+		}
+		pathIndex = 0;
+		return true;
+	}
+
+	if (parameters.size() == 2) {
+		if (parameters[0] == "/D") {
+			changeDrive = true;
+			pathIndex = 1;
+			return true;
+		}
+		return false;
+	}
+
+	return false;
 }
 
 int ChangeDirectory::RunProcess()

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -5,6 +5,10 @@
 
 #pragma once
 
+#ifdef TESTING_ENV
+#include "../tests/stdafx.h"
+#else
+
 #include <stdio.h>
 #include <tchar.h>
 #include <time.h> 
@@ -63,3 +67,5 @@
 
 #define SHELLS_PID 1
 // TODO: reference additional headers your program requires here
+
+#endif

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+# Create tests directory if it doesn't exist
+mkdir -p tests
+
+# Compile the test runner
+# We include 'tests' first so that 'stdafx.h' in tests/ is picked up instead of src/stdafx.h if included with ""
+# We define TESTING_ENV to use the test configuration in src/stdafx.h
+# We use -fpermissive because legacy C++ code might need it (as suggested by memory)
+# We don't link src/Utils.cpp because of Windows dependencies, relying on mock or unused symbols.
+g++ -I tests -I src \
+    tests/test_ChangeDirectory.cpp \
+    src/ChangeDirectory.cpp \
+    src/AbstractProcess.cpp \
+    -o tests/test_runner \
+    -DTESTING_ENV \
+    -std=c++11 -pthread -fpermissive
+
+# Run the tests
+./tests/test_runner

--- a/tests/stdafx.h
+++ b/tests/stdafx.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <string>
+#include <vector>
+#include <iostream>
+#include <thread>
+#include <atomic>
+#include <mutex>
+#include <algorithm>
+#include <map>
+#include <deque>
+
+using namespace std;
+
+#define SHELLS_PID 1
+#define ERROR_INVALID_FILE_ATTRIBUTES 123
+#define ERROR_FILE_NOT_FOUND 2
+
+class AbstractInput;
+class AbstractOutput;
+class File;
+class Kernel;
+class FileSystem;
+
+class File {
+public:
+    virtual ~File() {}
+    bool IsFolder() { return true; }
+};
+
+class AbstractInput {
+public:
+    virtual ~AbstractInput() {}
+    virtual void Close() {}
+};
+
+class AbstractOutput {
+public:
+    virtual ~AbstractOutput() {}
+    virtual void Close() {}
+    virtual void WriteLine(string s) {}
+};
+
+class Kernel {
+public:
+    virtual ~Kernel() {}
+    File* GetFile(string path, File* source, int& response) {
+         response = 0;
+         return new File();
+    }
+    bool UpdateProcessPathFile(int pid, File* file) { return true; }
+};
+
+// Include headers that we want to mock or use from source
+// We include Utils.h first as it is simple
+#include "Utils.h"
+
+// We include AbstractProcess.h as ChangeDirectory inherits from it
+#include "AbstractProcess.h"
+
+// We include ChangeDirectory.h because ChangeDirectory.cpp expects it from stdafx.h
+#include "ChangeDirectory.h"

--- a/tests/test_ChangeDirectory.cpp
+++ b/tests/test_ChangeDirectory.cpp
@@ -1,0 +1,75 @@
+#include "stdafx.h"
+#include "ChangeDirectory.h"
+#include <iostream>
+#include <string>
+
+using namespace std;
+
+int g_fail_count = 0;
+
+void run_test(string params, bool expected, string message) {
+    ChangeDirectory cd(0, 0, nullptr); // Kernel nullptr is safe for HasValidParameters
+    // Use Init to set parameters through AbstractProcess logic
+    // We pass nullptr for input/output/errorOutput as they are not used in HasValidParameters
+    cd.Init(nullptr, nullptr, nullptr, params);
+
+    bool result = cd.HasValidParameters();
+
+    if (result == expected) {
+        cout << "[PASS] " << message << " (params: \"" << params << "\")" << endl;
+    } else {
+        cout << "[FAIL] " << message << " (params: \"" << params << "\")" << endl;
+        cout << "  Expected: " << (expected ? "true" : "false") << ", Got: " << (result ? "true" : "false") << endl;
+        g_fail_count++;
+    }
+}
+
+int main() {
+    cout << "Running ChangeDirectory tests..." << endl;
+    cout << "Note: Parameters must be wrapped in single quotes as per Shell -> AbstractProcess protocol." << endl;
+
+    // Test cases based on code analysis and expected behavior
+
+    // 1. Empty parameters
+    // Expect: Valid (Show Help)
+    run_test("", true, "Empty parameters");
+
+    // 2. --help
+    // Expect: Valid (Show Help)
+    run_test("'--help'", true, "--help argument");
+
+    // 3. Simple path
+    // Expect: Valid
+    run_test("'C:\\Windows'", true, "Simple path");
+
+    // 4. Path with spaces (Simulating Shell processing: "C:\Program Files" -> 'C:\Program Files')
+    // Expect: Valid
+    run_test("'C:\\Program Files'", true, "Path with spaces");
+
+    // 5. /D switch with path
+    // Expect: Valid
+    run_test("'/D' 'C:\\Windows'", true, "/D switch with path");
+
+    // 6. /D switch without path
+    // Expect: Invalid (Should specify path)
+    run_test("'/D'", false, "/D switch only");
+
+    // 7. Invalid parameters (Two paths)
+    // Expect: Invalid
+    run_test("'path1' 'path2'", false, "Two paths");
+
+    // 8. Invalid switch (treated as path)
+    // Expect: Valid (Treated as directory named '/Invalid')
+    run_test("'/Invalid'", true, "Invalid switch treated as path");
+
+    // 9. Extra arguments with /D
+    // Expect: Invalid
+    run_test("'/D' 'path' 'extra'", false, "Extra arguments with /D");
+
+    if (g_fail_count > 0) {
+        cout << "\nTests Failed: " << g_fail_count << endl;
+        return 1;
+    }
+    cout << "\nAll tests passed!" << endl;
+    return 0;
+}


### PR DESCRIPTION
This PR addresses a logic issue in `ChangeDirectory::HasValidParameters` where it would return `true` prematurely, accepting invalid parameter combinations.

**Changes:**
1.  **Logic Fix**: Rewrote `HasValidParameters` to explicitly check parameter count and values, ensuring strict validation.
    *   Rejects `/D` without a path.
    *   Rejects multiple paths (e.g., `cd path1 path2`).
    *   Correctly handles single path, `/D` with path, and `--help`.
2.  **Test Infrastructure**:
    *   Created `tests/` directory.
    *   Added `tests/run_tests.sh` script to compile and run tests on Linux.
    *   Added `tests/stdafx.h` with mocks for `Kernel`, `File`, etc., to allow compiling core logic without Windows dependencies.
    *   Modified `src/stdafx.h` to include `tests/stdafx.h` when `TESTING_ENV` is defined.
3.  **Test Coverage**:
    *   Added `tests/test_ChangeDirectory.cpp` covering various scenarios (empty, help, valid path, invalid combinations).
    *   Tests verified the fix and mimic `Shell` behavior (single-quoted arguments).

**Verification:**
*   Ran `tests/run_tests.sh` successfully.
*   All tests passed, confirming the fix and correct behavior for edge cases.


---
*PR created automatically by Jules for task [6596159435532007429](https://jules.google.com/task/6596159435532007429) started by @Chlebnik*