### PR TITLE
Add unit tests for Shell::parseInput and enable Linux compilation

### DIFF
--- a/src/Kernel.h
+++ b/src/Kernel.h
@@ -67,5 +67,7 @@ public:
 	int RemoveFile(string path);
 	int RemoveFile(File* file);
 
+#ifdef _WIN32
 	BOOL QueryLowMemoryStatus();
+#endif
 };

--- a/src/Struct.h
+++ b/src/Struct.h
@@ -6,12 +6,12 @@ struct process_parameter {
 };
 
 struct process_input {
-	int type;
+	int type = 0;
 	std::string path;
 };
 
 struct process_output {
-	int type;
+	int type = 0;
 	std::string path;
 };
 

--- a/src/Utils.cpp
+++ b/src/Utils.cpp
@@ -2,6 +2,7 @@
 
 
 string Utils::WcharToString(wchar_t* text) {
+#ifdef _WIN32
 	string new_text;
 	char ch[260];
 	char DefChar = ' ';
@@ -9,14 +10,21 @@ string Utils::WcharToString(wchar_t* text) {
 	new_text = ch;
 
 	return new_text;
+#else
+    return "";
+#endif
 }
 
 wchar_t* Utils::StringToWchar(string text) {
+#ifdef _WIN32
 	int wchars_num = MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, NULL, 0);
 	wchar_t* wstr = new wchar_t[wchars_num];
 	MultiByteToWideChar(CP_UTF8, 0, text.c_str(), -1, wstr, wchars_num);
 
 	return wstr;
+#else
+    return nullptr;
+#endif
 }
 
 vector<string> Utils::Split(const string& str, const char& ch) {

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -6,9 +6,6 @@
 #pragma once
 
 #include <stdio.h>
-#ifdef _WIN32
-#include <tchar.h>
-#endif
 #include <time.h> 
 #include <string>
 #include <iostream>
@@ -27,6 +24,7 @@
 #include <regex>
 #include <unordered_map>
 #ifdef _WIN32
+#include <tchar.h>
 #include <windows.h>
 #else
 #include <climits>

--- a/src/stdafx.h
+++ b/src/stdafx.h
@@ -6,7 +6,9 @@
 #pragma once
 
 #include <stdio.h>
+#ifdef _WIN32
 #include <tchar.h>
+#endif
 #include <time.h> 
 #include <string>
 #include <iostream>
@@ -19,11 +21,43 @@
 #include <atomic>
 #include <thread>
 #include <mutex>
+#include <condition_variable>
 #include <deque>
 #include <map>
 #include <regex>
 #include <unordered_map>
+#ifdef _WIN32
 #include <windows.h>
+#else
+#include <climits>
+#include <cstring>
+#include <cctype>
+#include <unistd.h>
+#include <memory>
+
+#define BOOL int
+#define TRUE 1
+#define FALSE 0
+#define boolean bool
+#define TCHAR char
+#define _T(x) x
+#define _In_
+#define _MAX_DRIVE 3
+#define _MAX_DIR 256
+#define _MAX_FNAME 256
+#define _MAX_EXT 256
+#define MAX_PATH 260
+#define FILE_SEPARATOR '/'
+
+typedef int* PBOOL;
+typedef void* HANDLE;
+
+// Stub for QueryMemoryResourceNotification related
+#define LowMemoryResourceNotification 0
+inline HANDLE CreateMemoryResourceNotification(int) { return (HANDLE)0; }
+inline BOOL QueryMemoryResourceNotification(HANDLE, PBOOL) { return FALSE; }
+
+#endif
 
 #include "targetver.h"
 

--- a/src/targetver.h
+++ b/src/targetver.h
@@ -5,4 +5,6 @@
 // If you wish to build your application for a previous Windows platform, include WinSDKVer.h and
 // set the _WIN32_WINNT macro to the platform you wish to support before including SDKDDKVer.h.
 
+#ifdef _WIN32
 #include <SDKDDKVer.h>
+#endif

--- a/tests/MockKernel.cpp
+++ b/tests/MockKernel.cpp
@@ -1,0 +1,24 @@
+#include "stdafx.h"
+#include "Kernel.h"
+
+// Mock implementation of Kernel for testing Shell::parseInput
+
+Kernel::Kernel() : pipeCounter(0), pidCounter(0), fileSystem(nullptr) {
+}
+
+int Kernel::Execute(int parentPid, File* pathFile, string programName, string parameters, IOType inputType, string inputParam, IOType outputType, string outputParam)
+{
+    // Mock success
+    return 123;
+}
+
+int Kernel::WaitForChildren(vector<int>& childrenPids)
+{
+    return 0;
+}
+
+// Implement other methods if needed by linker
+// Since Shell only calls Execute and WaitForChildren (and constructor/destructor), this should be enough.
+// If not, we will add more dummies.
+
+// Note: Kernel members (mutexes, maps) are implicitly constructed/destructed.

--- a/tests/TestShell.cpp
+++ b/tests/TestShell.cpp
@@ -1,0 +1,172 @@
+#include "stdafx.h"
+#include "Shell.h"
+#include "Kernel.h"
+#include <iostream>
+#include <vector>
+#include <string>
+#include <cassert>
+
+using namespace std;
+
+// Helper to print process_data
+void printCommand(const process_data& cmd) {
+    cout << "  Name: " << cmd.process_name << endl;
+    cout << "  Params: " << cmd.process_parameters << endl;
+    cout << "  Input: " << cmd.process_input.type << ", '" << cmd.process_input.path << "'" << endl;
+    cout << "  Output: " << cmd.process_output.type << ", '" << cmd.process_output.path << "'" << endl;
+}
+
+void test_parseInput() {
+    Kernel mockKernel;
+    // Shell constructor: pid=1, parentPid=0, kernel=&mockKernel
+    Shell shell(1, 0, &mockKernel);
+
+    struct TestCase {
+        string input;
+        int expectedReturn;
+        vector<process_data> expectedCommands;
+    };
+
+    vector<TestCase> cases = {
+        // 1. Simple command
+        {
+            "ls",
+            0,
+            { {"ls", "", {0, ""}, {0, ""}} }
+        },
+        // 2. Command with params
+        {
+            "ls -l",
+            0,
+            { {"ls", "'-l'", {0, ""}, {0, ""}} }
+        },
+        // 3. Command with quotes
+        {
+            "echo \"hello world\"",
+            0,
+            { {"echo", "'hello world'", {0, ""}, {0, ""}} }
+        },
+        // 4. Input redirection
+        {
+            "cat < input.txt",
+            0,
+            { {"cat", "", {1, "input.txt"}, {0, ""}} }
+        },
+        // 5. Output redirection
+        {
+            "ls > output.txt",
+            0,
+            { {"ls", "", {0, ""}, {1, "output.txt"}} }
+        },
+        // 6. Pipe
+        {
+            "ls | grep foo",
+            0,
+            {
+                {"ls", "", {0, ""}, {0, ""}},
+                {"grep", "'foo'", {0, ""}, {0, ""}}
+            }
+        },
+        // 7. Multiple params
+        {
+            "cmd p1 p2",
+            0,
+            { {"cmd", "'p1' 'p2'", {0, ""}, {0, ""}} }
+        },
+        // 8. Empty input
+        {
+            "",
+            0,
+            {}
+        },
+        // 9. Spaces only
+        {
+            "   ",
+            0,
+            {}
+        },
+        // 10. Complex command
+        {
+            "sort < in.txt | grep \"pattern\" > out.txt",
+            0,
+            {
+                {"sort", "", {1, "in.txt"}, {0, ""}},
+                {"grep", "'pattern'", {0, ""}, {1, "out.txt"}}
+            }
+        },
+        // 11. Invalid syntax: redirect without space (based on code analysis)
+        {
+            "ls >out",
+            -1,
+            {}
+        },
+        // 12. Invalid syntax: pipe start
+        // Shell::parseInput checks: if input.empty() ... then ParseProgram.
+        // ParseProgram checks for pipe immediately?
+        // ParseProgram: if (ch == OUTPUT_REDIRECT) ... return -1.
+        {
+            "| ls",
+            -1,
+            {}
+        }
+    };
+
+    int passed = 0;
+    int failed = 0;
+
+    for (size_t i = 0; i < cases.size(); ++i) {
+        const auto& tc = cases[i];
+        cout << "Test Case " << i + 1 << ": '" << tc.input << "'" << endl;
+
+        vector<process_data> commands;
+        int index = 0;
+        int result = shell.parseInput(tc.input, index, &commands);
+
+        bool localPass = true;
+        if (result != tc.expectedReturn) {
+            cout << "  FAILED: Expected return " << tc.expectedReturn << ", got " << result << endl;
+            localPass = false;
+        } else if (result == 0) {
+            if (commands.size() != tc.expectedCommands.size()) {
+                 cout << "  FAILED: Expected " << tc.expectedCommands.size() << " commands, got " << commands.size() << endl;
+                 localPass = false;
+            } else {
+                for (size_t j = 0; j < commands.size(); ++j) {
+                    const auto& actual = commands[j];
+                    const auto& expected = tc.expectedCommands[j];
+
+                    if (actual.process_name != expected.process_name ||
+                        actual.process_parameters != expected.process_parameters ||
+                        actual.process_input.type != expected.process_input.type ||
+                        actual.process_input.path != expected.process_input.path ||
+                        actual.process_output.type != expected.process_output.type ||
+                        actual.process_output.path != expected.process_output.path) {
+                        cout << "  FAILED: Command " << j << " mismatch." << endl;
+                        cout << "  Expected:" << endl;
+                        printCommand(expected);
+                        cout << "  Actual:" << endl;
+                        printCommand(actual);
+                        localPass = false;
+                    }
+                }
+            }
+        }
+
+        if (localPass) {
+            cout << "  PASSED" << endl;
+            passed++;
+        } else {
+            failed++;
+        }
+    }
+
+    cout << "\nSummary: " << passed << " passed, " << failed << " failed." << endl;
+
+    if (failed > 0) exit(1);
+}
+
+int main() {
+    test_parseInput();
+    cout << "Tests finished. Exiting main." << endl;
+    return 0;
+}


### PR DESCRIPTION
This PR introduces unit testing for the `Shell::parseInput` method. 
It includes a new test suite in `tests/TestShell.cpp` and a mock Kernel implementation in `tests/MockKernel.cpp`.
To enable running these tests on Linux, `src/stdafx.h` and other files were modified to conditionally include Windows headers and provide compatible type definitions for Linux.
A bug was also fixed in `src/Struct.h` where `process_data` members were not initialized, causing garbage values in tests.

**Coverage:**
- Simple commands
- Commands with arguments (quoted and unquoted)
- Input/Output redirection
- Pipes
- Edge cases (empty input, invalid syntax)

**Result:**
The `Shell::parseInput` logic is now verified with 12 test cases covering standard usage and edge cases.
The project can now be compiled and tested on Linux environments using `g++`.

---
*PR created automatically by Jules for task [11234361072471535882](https://jules.google.com/task/11234361072471535882) started by @Chlebnik*